### PR TITLE
feedback nils:

### DIFF
--- a/src/main/java/ch/uzh/ifi/hase/soprafs25/service/GroupService.java
+++ b/src/main/java/ch/uzh/ifi/hase/soprafs25/service/GroupService.java
@@ -86,6 +86,11 @@ public class GroupService {
         if (groupRepository.findByGroupName(groupName) != null) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "This group name is already taken");
         }
+
+        String groupName_removed_all_spaces_in_front_and_back = groupName.trim();
+        if (groupRepository.findByGroupName(groupName_removed_all_spaces_in_front_and_back) != null) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "This group name is already taken");
+        }
     }
 
     private String generateUniqueName() {


### PR DESCRIPTION
This is very niche, and I tried finding a “bug” (it is not actually a bug, but you could easily fix it if you wanted to). You can create a new group with the same name but with an additional space in front. It is then shown as the same name (even though the space in front is still shown in the “edit group name”). You already checked the edge case if someone adds a space to the end, but not in front: